### PR TITLE
2024 update: sync with internal repo

### DIFF
--- a/chart/templates/challenge-manager.yaml
+++ b/chart/templates/challenge-manager.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: challenge-manager
       containers:
       - name: challenge-manager
-        image: {{ .Values.googleRegion }}-docker.pkg.dev/{{ .Values.googleProject }}/{{ .Values.googleRepositoryName }}/services/challenge-manager:latest
+        image: {{ .Values.googleRegion }}-docker.pkg.dev/{{ .Values.googleProject }}/{{ .Values.googleRepositoryName }}/challenge-manager:latest
         readinessProbe:
           httpGet:
             port: 3000
@@ -70,7 +70,7 @@ spec:
   ports:
     - port: 3000
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: challenge-manager
@@ -117,6 +117,7 @@ rules:
       - namespaces
       - secrets
       - networkpolicies
+      - configmaps
     verbs:
       - create
       - delete

--- a/chart/templates/landing.yaml
+++ b/chart/templates/landing.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: web
-        image: {{ .Values.googleRegion }}-docker.pkg.dev/{{ .Values.googleProject }}/{{ .Values.googleRepositoryName }}/services/landing:latest
+        image: {{ .Values.googleRegion }}-docker.pkg.dev/{{ .Values.googleProject }}/{{ .Values.googleRepositoryName }}/landing:latest
         resources:
 {{ toYaml (index  .Values "landing").quota | indent 10 }}
         ports:
@@ -40,7 +40,7 @@ spec:
     - port: 80
 ---
 # default ingressroute
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: landing

--- a/chart/templates/namespaces.yaml
+++ b/chart/templates/namespaces.yaml
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/instance: {{ $relname }}
     app.kubernetes.io/component: {{ . }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: secure-headers

--- a/chart/templates/traefik.yaml
+++ b/chart/templates/traefik.yaml
@@ -1,6 +1,6 @@
 {{- $relname := .Release.Name -}}
 {{- range .Values.challengeNamespaces }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: hsts
@@ -12,7 +12,7 @@ spec:
     stsIncludeSubdomains: true
 ---
 {{- end }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: hsts
@@ -23,7 +23,7 @@ spec:
     forceSTSHeader: true
     stsIncludeSubdomains: true
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: TLSStore
 metadata:
   name: default

--- a/scripts/cluster-configure
+++ b/scripts/cluster-configure
@@ -7,7 +7,7 @@ PROJECT_ID=`gcloud config get-value project`
 KUBECTF_NAMESPACE="kubectf"
 
 # ask the questions
-CLUSTER_NAME=`ask_with_default "Cluster name" ""`
+CLUSTER_NAME=`ask_with_default "Cluster name" "ctf-cluster"`
 KUBECTF_NAMESPACE=`ask_with_default "KubeCTF Instance (should be the same as in values.yaml)" "$KUBECTF_NAMESPACE"`
 SERVICE_ACCOUNT_CHALLENGE_MANAGER="gke-challenge-manager"
 

--- a/scripts/cluster-deploy
+++ b/scripts/cluster-deploy
@@ -7,7 +7,7 @@ set -e
 PROJECT_ID=`gcloud config get-value project`
 CLUSTER_NAME="ctf-cluster"
 CLUSTER_REGION="us-central1-a"
-CLUSTER_VERSION="1.27.3-gke.100"
+CLUSTER_VERSION="1.29.4-gke.1043002"
 MACHINE_TYPE="e2-medium"
 DISK_SIZE="30"
 DISK_TYPE="pd-standard"

--- a/scripts/cluster-install
+++ b/scripts/cluster-install
@@ -19,6 +19,8 @@ helm install traefik traefik/traefik \
     --create-namespace \
     --values <(cat <<EOF
 installCRDs: true
+core:
+  defaultRuleSyntax: v2
 deployment:
   kind: DaemonSet
 providers:
@@ -34,12 +36,14 @@ service:
 ports:
   blockchain:
     port: 8545
-    expose: true
+    expose: 
+      default: true
     protocol: 'TCP'
     exposedPort: 8545
   tcpsecure:
     port: 40000
-    expose: true
+    expose: 
+      default: true
     protocol: 'TCP'
     exposedPort: 32000
     tls:

--- a/scripts/services-build
+++ b/scripts/services-build
@@ -9,25 +9,41 @@ REPO_NAME="ductf"
 REPO_LOCATION="australia-southeast1"
 
 PROJECT_ID=`ask_with_default "Project ID" "$PROJECT_ID"`
-REPO_NAME=`ask_with_default "AR Repo Name" "$REPO_NAME"`
+# REPO_NAME=`ask_with_default "AR Repo Name" "$REPO_NAME"`
 REPO_LOCATION=`ask_with_default "AR Repo Location" "$REPO_LOCATION"`
 
 
 gcloud services enable artifactregistry.googleapis.com
 gcloud services enable cloudbuild.googleapis.com
 
-# Create artifact registry repo
-gcloud artifacts repositories create ${REPO_NAME} \
-  --repository-format=docker \
-  --location=${REPO_LOCATION} \
-  --description="registry for CTF related images" 
+# set +e
+# Check if repo already exists
+# gcloud artifacts repositories describe ${REPO_NAME} \
+#   --location=${REPO_LOCATION} \
+#   --project=${PROJECT_ID}
+
+# set -e
+
+# if [ $? -eq 1 ]
+# then
+#   echo "Creating repo: ${REPO_NAME} in ${REPO_LOCATION}"
+#   # Create artifact registry repo
+#   gcloud artifacts repositories create ${REPO_NAME} \
+#     --repository-format=docker \
+#     --location=${REPO_LOCATION} \
+#     --project=${PROJECT_ID} \
+#     --description="registry for CTF related images" 
+# fi
 
 
 gcloud builds submit ./services/challenge-manager/ \
   --config ./services/challenge-manager/cloudbuild.yaml \
   --region ${REPO_LOCATION} \
-  --async
+  --project=${PROJECT_ID} \
+  --async 
+
 gcloud builds submit ./services/landing/ \
   --config ./services/landing/cloudbuild.yaml \
   --region ${REPO_LOCATION} \
+  --project=${PROJECT_ID} \
   --async

--- a/services/challenge-manager/cloudbuild.yaml
+++ b/services/challenge-manager/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - id: build
     name: 'gcr.io/kaniko-project/executor:latest'
     args:
-      - --destination=$LOCATION-docker.pkg.dev/$PROJECT_ID/ductf/services/challenge-manager
+      - --destination=$LOCATION-docker.pkg.dev/$PROJECT_ID/infra/services/challenge-manager
       - --cache=true
       - --cache-ttl=168h
 #  - --context=dir://services/challenge-manager

--- a/services/landing/cloudbuild.yaml
+++ b/services/landing/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - id: build
     name: "gcr.io/kaniko-project/executor:latest"
     args:
-      - --destination=$LOCATION-docker.pkg.dev/$PROJECT_ID/ductf/services/landing
+      - --destination=$LOCATION-docker.pkg.dev/$PROJECT_ID/infra/services/landing
       - --cache=true
       - --cache-ttl=168h
 #  - --context=dir://services/landing

--- a/services/landing/public/subdomain.js
+++ b/services/landing/public/subdomain.js
@@ -5,7 +5,7 @@
 
  function checkChallengeReady() {
   const host = window.location.origin;
-  fetch(host)
+  fetch(host, {cache: 'no-store'})
     .then(res => {
       if (res.status === 200) {
         // Parse response text
@@ -17,7 +17,10 @@
               location.reload(true) 
             }
           })
-      } else { console.log("instance not ready")} 
+      } else if (res.status < 500) {
+        location.reload(true)
+      }
+      else { console.log("instance not ready")} 
     })
     .catch(e => console.error(e))
  }

--- a/templates/whoami/kube-isolated.yaml
+++ b/templates/whoami/kube-isolated.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: kube-ctf.downunderctf.com/v1
 kind: IsolatedChallenge
 metadata:
@@ -71,7 +70,7 @@ spec:
         - port: 80
           name: port-80
     ---
-    apiVersion: traefik.containo.us/v1alpha1
+    apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
       name: ingress-ctf-{{ deployment_id }}


### PR DESCRIPTION
- update traefik crds to use the new `traefik.io/v1alpha1` namespace
- small changes to challenge manager to remove caching for specific endpoint